### PR TITLE
Change to new user activation email url

### DIFF
--- a/models/class.newuser.php
+++ b/models/class.newuser.php
@@ -67,7 +67,7 @@ class User
 				$mail = new userPieMail();
 			
 				//Build the activation message
-				$activation_message = lang("ACTIVATION_MESSAGE",array($websiteUrl,$this->activation_token));
+				$activation_message = lang("ACTIVATION_MESSAGE",array("{$websiteUrl}/",$this->activation_token));
 				
 				//Define more if you want to build larger structures
 				$hooks = array(


### PR DESCRIPTION
The activation url and token was formatted as:

http://www.[yoursite]activate-account.php?token=[randomstring]

whereas it needed a / in between [yoursite] and activate-account.
