### PR TITLE
Restored Email Activation Message

### DIFF
--- a/models/class.newuser.php
+++ b/models/class.newuser.php
@@ -67,7 +67,7 @@ class User
 				$mail = new userPieMail();
 			
 				//Build the activation message
-				$activation_message = lang("ACTIVATION_MESSAGE",array("{$websiteUrl}/",$this->activation_token));
+				$activation_message = lang("ACTIVATION_MESSAGE",array($websiteUrl,$this->activation_token));
 				
 				//Define more if you want to build larger structures
 				$hooks = array(


### PR DESCRIPTION
Re-Read the config file and realised I had the trailing slash in my $websiteUrl Missing...
